### PR TITLE
Ternary Sniff: bug fix for empty

### DIFF
--- a/Behance/Sniffs/ControlStructures/TernarySniff.php
+++ b/Behance/Sniffs/ControlStructures/TernarySniff.php
@@ -208,7 +208,8 @@ class Behance_Sniffs_ControlStructures_TernarySniff implements PHP_CodeSniffer_S
     }
 
     return ( $this->_tokens[ $index - 1 ]['code'] === T_WHITESPACE ) ||
-           ( $this->_tokens[ $index - 1 ]['code'] === T_ISSET );
+           ( $this->_tokens[ $index - 1 ]['code'] === T_ISSET ) ||
+           ( $this->_tokens[ $index - 1 ]['code'] === T_EMPTY );
 
   } // _isPrecededByWhitespaceOrDesiredToken
 


### PR DESCRIPTION
@kgeorgiev @bmax 

This is a quick bug-fix before the release, because Kras was getting a false error with the following code:

```
$adapter_options = ( !empty( $options[ $url ] ) )
                   ? $options[ $url ]
                   : [];
```

This function will be removed anyway in a later PR that uses the matching_parens attribute, which bmax showed me after I had finished writing the initial sniff.

In any case, this is just a quick fix to make the sniff work until it can be modified later.